### PR TITLE
Add styling for Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ For macOS:
 @import "custom/_megabar-disable.css";
 ```
 
+### Add Developer Tools styling
+
+Set theme to dark in Firefox Developer Tools [settings](https://developer.mozilla.org/en-US/docs/Tools/Settings). Then, add the following line to `userContent.css`:
+
+```
+@import "custom/_dev-tools.css";
+```
+
 ## Support
 
 If you love my work and would like to support my future endeavors I would gladly drink a coffee with you :)

--- a/custom/_dev-tools.css
+++ b/custom/_dev-tools.css
@@ -1,0 +1,46 @@
+/*
+ * Variables for devtools are available at: https://developer.mozilla.org/en-US/docs/Tools/DevToolsColors
+ */
+
+:root.theme-dark {
+    /*
+     * Chrome colors
+     */
+    --theme-tab-toolbar-background: var(--moonlight-gray-3) !important;
+    --theme-toolbar-background: var(--moonlight-gray-3) !important;
+    --theme-selection-background: var(--moonlight-gray-5) !important;
+    --theme-selection-color: #fff !important;
+    --theme-splitter-color: var(--moonlight-gray-1) !important;
+    --theme-comment: var(--moonlight-gray-10) !important;
+
+    /*
+     * Content Colors
+     */
+    --theme-body-background: var(--moonlight-gray-2) !important;
+    --theme-sidebar-background: var(--moonlight-gray-3) !important;
+    --theme-contrast-background: var(--moonlight-gray-3) !important;
+
+    /*
+     * Text Colors
+     */
+    --theme-body-color: var(--moonlight-gray-10-alt) !important;
+    --theme-body-color-alt: var(--moonlight-desaturated-gray) !important;
+    --theme-content-color1: #fff !important;
+    --theme-content-color2: var(--moonlight-gray-10) !important;
+    --theme-content-color3: var(--moonlight-gray-6) !important;
+
+
+    /*
+     * Highlight Colors
+     */
+    --theme-highlight-blue: var(--moonlight-blue) !important;
+    --theme-highlight-purple: var(--moonlight-purple) !important;
+    --theme-highlight-pink: var(--moonlight-pink) !important;
+    --theme-highlight-red: var(--moonlight-light-red) !important;
+    --theme-highlight-orange: var(--moonlight-dark-orange) !important;
+    --theme-highlight-lightorange: var(--moonlight-orange) !important;
+    --theme-highlight-green: var(--moonlight-teal) !important;
+    --theme-highlight-bluegrey: var(--moonlight-gray-6) !important;
+    --theme-highlight-yellow: var(--moonlight-yellow) !important;
+}
+


### PR DESCRIPTION
* Add instructions on readme to add dev tools styling
* Add `_dev-tools.css` with css variables

It seems that not all of the dev tools is themeable. Some of the colors
come from whether you are in light or dark theme. I was not able to get
the light theme to look good by adjusting the css variables. Many panels
had a white background with dark text. Because of this I made this
feature an opt-in thing so that users can see the instructions of
setting the theme to dark.